### PR TITLE
Remove version check for Xfce dependencies

### DIFF
--- a/extras/pacman/generate-pkgbuild-files.sh
+++ b/extras/pacman/generate-pkgbuild-files.sh
@@ -110,7 +110,7 @@ get_depends()
 			mate)		printf -- " 'mate-panel>=1.7.0'" ;;
 			standalone)	return 0 ;;
 			systray)	return 0 ;;
-			xfce4)		printf -- " 'libxfce4util>=4.12.0' 'xfce4-panel>=4.12.0'" ;;
+			xfce4)		printf -- " 'libxfce4util' 'xfce4-panel'" ;;
 		esac
 	fi
 }


### PR DESCRIPTION
For some reason the version check fails to detect version 4.13.3 as >=4.12.0