### PR TITLE
indicator: Don't render if not full allocation given

### DIFF
--- a/indicator/plugin.c
+++ b/indicator/plugin.c
@@ -49,6 +49,8 @@ static int icon_current_index=0;
 static gboolean indicator_connected;
 static GtkWidget *graphs_menu_items[GRAPH_MAX];
 
+static int lasttick;
+
 static void
 indicator_cleanup(int sig)
 {
@@ -153,9 +155,9 @@ indicator_update_pixbuf(MultiloadPlugin *ma)
 	if (error != NULL) {
 		g_error("Cannot save Multiload-ng window to temporary buffer: %s\n", error->message);
 		g_clear_error(&error);
-	} else
+	} else {
 		app_indicator_set_icon(indicator, icon_filename[icon_current_index]);
-
+	}
 	icon_current_index = 1-icon_current_index;
 	cairo_surface_destroy (surface);
 	cairo_destroy (cr);
@@ -165,6 +167,13 @@ static void
 indicator_graph_update_cb(LoadGraph *g, gpointer user_data)
 {
 	GtkAllocation allocation;
+
+	// Don't tick too often!
+	int now = time(NULL);
+	if (now - lasttick < 1) {
+		return;
+	}
+	lasttick = now;
 
 	indicator_update_menu(g->multiload);
 

--- a/indicator/plugin.c
+++ b/indicator/plugin.c
@@ -179,11 +179,18 @@ indicator_graph_update_cb(LoadGraph *g, gpointer user_data)
 	}
 
 	// resize widget and offscreen window to fit into panel
+	int icon_height = indicator_get_icon_height();
 	if (multiload_get_orientation(g->multiload) == GTK_ORIENTATION_HORIZONTAL)
-		gtk_widget_set_size_request(GTK_WIDGET(g->multiload->container), multiload_calculate_size_request(g->multiload), indicator_get_icon_height());
+		gtk_widget_set_size_request(GTK_WIDGET(g->multiload->container), multiload_calculate_size_request(g->multiload), icon_height);
 	else
-		gtk_widget_set_size_request(GTK_WIDGET(g->multiload->container), 120, indicator_get_icon_height()); //TODO 120 should not be hardcoded
+		gtk_widget_set_size_request(GTK_WIDGET(g->multiload->container), 120, icon_height); //TODO 120 should not be hardcoded
+
 	gtk_widget_get_allocation (GTK_WIDGET(g->multiload->container), &allocation);
+	if (allocation.height != icon_height) {
+		// If we render now then we don't recover, so skip it
+		return;
+	}
+
 	gtk_window_resize(GTK_WINDOW(offscr), allocation.width, allocation.height);
 
 	indicator_update_pixbuf(g->multiload);


### PR DESCRIPTION
If we render when we don't get a full gtk allocation then the icon never resizes to the correct size, so skip rendering the image if so.